### PR TITLE
libsass API upgrade and build changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Look at the file sass/version.h to find your installed libsass version.  This co
 Over time there was some mixing of C++ delete and C free in libsass API.  The library libsass should free passed strings.
 Look at the file sass/version.h to find your installed libsass version.  This code should work with 3.3.x, 3.4.x and when released 3.5.x.
 
-Set CFLAGS=-DTCLSAS_CALLER_FREE to free strings passed to the API.
+If you have version of libsass older than 3.3.x, then set CFLAGS=-DTCLSAS_CALLER_FREE to free strings passed to the API.
 
 ### Configuration
  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+### libsass version support
+
+The libsass library has several API changes over time.  So, the code has dependencies on the libsass version.
+Look at the file sass/version.h to find your installed libsass version.  This code should work with 3.3.x, 3.4.x and when released 3.5.x.
+
+Over time there was some mixing of C++ delete and C free in libsass API.  The library libsass should free passed strings.
+Look at the file sass/version.h to find your installed libsass version.  This code should work with 3.3.x, 3.4.x and when released 3.5.x.
+
+Set CFLAGS=-DTCLSAS_CALLER_FREE to free strings passed to the API.
+
+### Configuration
+ 
+You should be able to build with
+
+    autoreconf && ./configure && make && make install
+
+If you need to adjust the paths to locate libsass, use the CFLAGS and LDFLAGS variables to pass the paths to configure.
 
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 ### libsass version support
 
-The libsass library has several API changes over time.  So, the code has dependencies on the libsass version.
-Look at the file sass/version.h to find your installed libsass version.  This code should work with 3.3.x, 3.4.x and when released 3.5.x.
+The libsass library has several API changes over time.  The code has source dependencies on the libsass version.
+Check your version of the libsass library. This code should work with 3.3.x, 3.4.x and beta 3.5.x.
 
-Over time there was some mixing of C++ delete and C free in libsass API.  The library libsass should free passed strings.
-Look at the file sass/version.h to find your installed libsass version.  This code should work with 3.3.x, 3.4.x and when released 3.5.x.
+Over time there was some mixing of C++ delete and C free in libsass API.  That can corrupt the heap.  The library libsass should free passed strings.  But as the API evolved, there are versions that do not free all the strings passed to the API calls.  This can result in memory leaks.  It looks like for tclsass the libsass 3.5.x will address all this issue.  The addition of sass_delete_options() will complete the memory management fixes.
 
-If you have version of libsass older than 3.3.x, then set CFLAGS=-DTCLSAS_CALLER_FREE to free strings passed to the API.
+If you have version of libsass older than 3.3.x, then set CFLAGS=-DTCLSASS_CALLER_FREE to free strings passed to the API. THIS HAS NOT BEEN TESTED.  You will have to check the behavior of your specific libsass version.
 
 ### Configuration
  

--- a/configure
+++ b/configure
@@ -5332,25 +5332,6 @@ done
     done
 
 
-
-    vars="-I../libsass"
-    for i in $vars; do
-	PKG_INCLUDES="$PKG_INCLUDES $i"
-    done
-
-
-
-    vars="-L../libsass/lib -lsass"
-    for i in $vars; do
-	if test "${TEA_PLATFORM}" = "windows" -a "$GCC" = "yes" ; then
-	    # Convert foo.lib to -lfoo for GCC.  No-op if not *.lib
-	    i=`echo "$i" | sed -e 's/^\([^-].*\)\.lib$/-l\1/i'`
-	fi
-	PKG_LIBS="$PKG_LIBS $i"
-    done
-
-
-
     PKG_CFLAGS="$PKG_CFLAGS "
 
 

--- a/configure.in
+++ b/configure.in
@@ -74,7 +74,7 @@ TEA_ADD_STUB_SOURCES([])
 TEA_ADD_TCL_SOURCES([helper.tcl])
 
 AC_CHECK_HEADERS([sass/context.h])
-AC_LIBS([sass])
+AC_CHECK_LIB([sass],[libsass_version],, [AC_MSG_ERROR([unable to find libsass library])])
 
 #--------------------------------------------------------------------
 #

--- a/configure.in
+++ b/configure.in
@@ -67,11 +67,14 @@ TEA_SETUP_COMPILER
 
 TEA_ADD_SOURCES([tclsass.c])
 TEA_ADD_HEADERS([generic/tclsass.h])
-TEA_ADD_INCLUDES([-I../libsass])
-TEA_ADD_LIBS([-L../libsass/lib -lsass])
+TEA_ADD_INCLUDES([])
+TEA_ADD_LIBS([])
 TEA_ADD_CFLAGS([])
 TEA_ADD_STUB_SOURCES([])
 TEA_ADD_TCL_SOURCES([helper.tcl])
+
+AC_CHECK_HEADERS([sass/context.h])
+AC_LIBS([sass])
 
 #--------------------------------------------------------------------
 #

--- a/generic/tclsass.c
+++ b/generic/tclsass.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>		/* NOTE: For free(). */
 #include <string.h>		/* NOTE: For strlen(), strcmp(), strdup(). */
 #include "tcl.h"		/* NOTE: For public Tcl API. */
-#include "sass_context.h"	/* NOTE: For public libsass API. */
+#include "sass/context.h"	/* NOTE: For public libsass API. */
 #include "pkgVersion.h"		/* NOTE: Package version information. */
 #include "tclsassInt.h"		/* NOTE: For private package API. */
 #include "tclsass.h"		/* NOTE: For public package API. */

--- a/generic/tclsass.c
+++ b/generic/tclsass.c
@@ -994,7 +994,9 @@ static int CompileForType(
 	    sass_compile_data_context(ctxPtr);
 	    SetResultFromContext(interp, (struct Sass_Context *)ctxPtr);
 	    sass_delete_data_context(ctxPtr);
+#ifdef TCLSAS_CALLER_FREE
 	    free(zDup);
+#endif
 
 	    return TCL_OK;
 	}
@@ -1420,7 +1422,12 @@ static int SassObjCmd(
 
 done:
     if (optsPtr != NULL) {
-	free(optsPtr); /* libsass 3.5 will have sass_delete_options */
+#ifdef HAVE_SASS_DELETE_OPTIONS
+	/* libsass 3.5.x adds the delete function to match the make function. */
+	sass_delete_options(optsPtr);
+#else
+	free(optsPtr);
+#endif
 	optsPtr = NULL;
     }
 

--- a/generic/tclsass.c
+++ b/generic/tclsass.c
@@ -1420,7 +1420,7 @@ static int SassObjCmd(
 
 done:
     if (optsPtr != NULL) {
-	free(optsPtr); /* HACK: No official destructor function. */
+	sass_delete_options(optsPtr);
 	optsPtr = NULL;
     }
 

--- a/generic/tclsass.c
+++ b/generic/tclsass.c
@@ -1420,7 +1420,7 @@ static int SassObjCmd(
 
 done:
     if (optsPtr != NULL) {
-	sass_delete_options(optsPtr);
+	free(optsPtr); /* libsass 3.5 will have sass_delete_options */
 	optsPtr = NULL;
     }
 

--- a/generic/tclsass.c
+++ b/generic/tclsass.c
@@ -994,7 +994,7 @@ static int CompileForType(
 	    sass_compile_data_context(ctxPtr);
 	    SetResultFromContext(interp, (struct Sass_Context *)ctxPtr);
 	    sass_delete_data_context(ctxPtr);
-#ifdef TCLSAS_CALLER_FREE
+#ifdef TCLSASS_CALLER_FREE
 	    free(zDup);
 #endif
 


### PR DESCRIPTION
libsass changed the paths to the API header: sass_context.h to sass/context.h.
GNU malloc was reporting double frees on strings passed to the API call.  Conditionally compile out the extra free for version 3.4.4 of libsass.

Changed the autoconf to use a standard method to locate libsass and the header file.